### PR TITLE
feat: add token budget management per agent (MAX_TOKENS_PER_AGENT)

### DIFF
--- a/src/junior/agent/pydantic.py
+++ b/src/junior/agent/pydantic.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import structlog
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent, RunContext
+from pydantic_ai.usage import UsageLimits
 
 from junior.config import Settings
 from junior.models import (
@@ -152,6 +153,11 @@ async def _review_async(
     deps = ReviewDeps(project_dir=settings.ci_project_dir, max_file_size=settings.max_file_size)
     user_msg = build_user_message(context)
     project_instructions = read_project_instructions(settings.ci_project_dir)
+    usage_limits = (
+        UsageLimits(response_tokens_limit=settings.max_tokens_per_agent)
+        if settings.max_tokens_per_agent
+        else None
+    )
 
     logger.info(
         "invoking pydantic-ai review",
@@ -184,7 +190,7 @@ async def _review_async(
 
     async def _run_with_limit(agent):
         async with semaphore:
-            return await agent.run(user_msg, deps=deps)
+            return await agent.run(user_msg, deps=deps, usage_limits=usage_limits)
 
     raw_results = await asyncio.gather(
         *(_run_with_limit(agent) for agent in agents),

--- a/src/junior/config.py
+++ b/src/junior/config.py
@@ -95,6 +95,7 @@ class Settings(BaseSettings):
     source: str = "auto"  # auto, staged, commit, branch
     max_file_size: int = 100_000
     max_concurrent_agents: int = 3
+    max_tokens_per_agent: int = 0  # 0 = no limit
     log_level: str = "INFO"
 
     # Publish options


### PR DESCRIPTION
- Add max_tokens_per_agent setting (default: 0 = no limit)
- Pass UsageLimits to pydantic-ai agent.run() when limit is set
- Limits response tokens per sub-agent to prevent runaway costs